### PR TITLE
#2 Divide `RouteFunction`s

### DIFF
--- a/api/src/main/java/com/bringback/yourlink/api/handler/YourTagHandler.java
+++ b/api/src/main/java/com/bringback/yourlink/api/handler/YourTagHandler.java
@@ -1,0 +1,27 @@
+package com.bringback.yourlink.api.handler;
+
+import com.bringback.yourlink.api.model.YourLink;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class YourTagHandler {
+    public Mono<ServerResponse> getYourTags(ServerRequest request) {
+        List<YourLink> dummyList = new ArrayList<>();
+        dummyList.add(new YourLink("http://your.tags.com"));
+
+        Flux<YourLink> yourLinkFlux = Flux.fromIterable(dummyList);
+
+        return ServerResponse
+                .ok()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(yourLinkFlux, YourLink.class);
+    }
+}

--- a/api/src/main/java/com/bringback/yourlink/api/router/RootRouter.java
+++ b/api/src/main/java/com/bringback/yourlink/api/router/RootRouter.java
@@ -1,0 +1,31 @@
+package com.bringback.yourlink.api.router;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.server.RequestPredicates;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
+import static org.springframework.web.reactive.function.server.RouterFunctions.nest;
+
+@Configuration
+public class RootRouter {
+
+    private final YourLinkRouter yourLinkRouter;
+
+    private final YourTagRouter yourTagRouter;
+
+    @Autowired
+    public RootRouter(YourLinkRouter yourLinkRouter, YourTagRouter yourTagRouter) {
+        this.yourLinkRouter = yourLinkRouter;
+        this.yourTagRouter = yourTagRouter;
+    }
+
+    @Bean
+    public RouterFunction<ServerResponse> routeAPIs() {
+        return nest(RequestPredicates.path("/api/v1"),
+                yourLinkRouter.routeYourLink()
+                        .and(yourTagRouter.routeYourTag()));
+    }
+}

--- a/api/src/main/java/com/bringback/yourlink/api/router/YourTagRouter.java
+++ b/api/src/main/java/com/bringback/yourlink/api/router/YourTagRouter.java
@@ -1,6 +1,6 @@
 package com.bringback.yourlink.api.router;
 
-import com.bringback.yourlink.api.handler.YourLinkHandler;
+import com.bringback.yourlink.api.handler.YourTagHandler;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -12,19 +12,19 @@ import static org.springframework.web.reactive.function.server.RequestPredicates
 import static org.springframework.web.reactive.function.server.RouterFunctions.route;
 
 @Component
-public class YourLinkRouter {
+public class YourTagRouter {
 
-    private final YourLinkHandler yourLinkHandler;
+    private final YourTagHandler yourTagHandler;
 
     @Autowired
-    public YourLinkRouter(YourLinkHandler yourLinkHandler) {
-        this.yourLinkHandler = yourLinkHandler;
+    public YourTagRouter(YourTagHandler yourTagHandler) {
+        this.yourTagHandler = yourTagHandler;
     }
 
-    public RouterFunction<ServerResponse> routeYourLink() {
+    public RouterFunction<ServerResponse> routeYourTag() {
         return route(RequestPredicates
-                        .GET("/your/links")
+                        .GET("/your/tags")
                         .and(accept(MediaType.APPLICATION_JSON)),
-                yourLinkHandler::getYourLinks);
+                yourTagHandler::getYourTags);
     }
 }


### PR DESCRIPTION
Devide `RouteFunction`s for another APIs

- Add prefix `/api/v1` to path