### PR TITLE
Integrate with ElasticSearch for YourLink

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # your-link
+
+
+### For local test with docker
+#### Prerequisites
+Make sure you have already installed both Docker Engine and Docker Compose.  
+https://docs.docker.com/compose/install/
+
+#### Run ElasticSearch 
+ElasticSearch is used for saving YourLink data.
+You can run two ElasticSearch and Kibana with below command. 
+```
+$ docker-compose -f docker/docker-compose-es.yml up
+```
+ElasticSearch will use `9200` and `9201` port of your host.   
+And Kibana will use `5601` port of your host.   
+So You can search test data in http://127.0.0.1:5601 

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -39,8 +39,13 @@ repositories {
 
 mainClassName = 'com.bringback.yourlink.api.ApiApplication'
 
+def elasticSearchVersion = '6.5.4'
+
 dependencies {
     compile 'org.springframework.boot:spring-boot-starter-webflux'
+
+    compile 'org.elasticsearch:elasticsearch:' + elasticSearchVersion
+    compile 'org.elasticsearch.client:elasticsearch-rest-high-level-client:' + elasticSearchVersion
 
     apt 'org.projectlombok:lombok:1.18.4'
     compileOnly 'org.projectlombok:lombok:1.18.4'

--- a/api/src/main/java/com/bringback/yourlink/api/handler/YourLinkHandler.java
+++ b/api/src/main/java/com/bringback/yourlink/api/handler/YourLinkHandler.java
@@ -1,6 +1,8 @@
 package com.bringback.yourlink.api.handler;
 
 import com.bringback.yourlink.api.model.YourLink;
+import com.bringback.yourlink.api.repository.YourLinkRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.server.ServerRequest;
@@ -13,6 +15,27 @@ import java.util.List;
 
 @Component
 public class YourLinkHandler {
+    private final YourLinkRepository yourLinkRepository;
+
+    @Autowired
+    public YourLinkHandler(YourLinkRepository yourLinkRepository) {
+        this.yourLinkRepository = yourLinkRepository;
+    }
+
+    public Mono<ServerResponse> saveYourLink(ServerRequest request) {
+        // TODO need to change after logged-in user email
+        List<String> userIdHeader = request.headers().header("x-yourlink-userid");
+        String userId = userIdHeader.get(0);
+
+        Mono<YourLink> yourLinkMono = request.bodyToMono(YourLink.class);
+        yourLinkRepository.saveYourLink(userId, yourLinkMono);
+
+        return ServerResponse
+                .ok()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(Mono.empty(), Void.class);
+    }
+
     public Mono<ServerResponse> getYourLinks(ServerRequest request) {
         List<YourLink> dummyList = new ArrayList<>();
         dummyList.add(new YourLink("http://naver.com"));

--- a/api/src/main/java/com/bringback/yourlink/api/model/YourLink.java
+++ b/api/src/main/java/com/bringback/yourlink/api/model/YourLink.java
@@ -3,10 +3,13 @@ package com.bringback.yourlink.api.model;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Data
 @NoArgsConstructor
 public class YourLink {
     private String url;
+    private List<String> tags;
     private boolean read;
 
     public YourLink(String url) {

--- a/api/src/main/java/com/bringback/yourlink/api/repository/YourLinkRepository.java
+++ b/api/src/main/java/com/bringback/yourlink/api/repository/YourLinkRepository.java
@@ -1,0 +1,65 @@
+package com.bringback.yourlink.api.repository;
+
+import com.bringback.yourlink.api.support.elasticsearch.ElasticSearchClient;
+import com.bringback.yourlink.api.model.YourLink;
+import lombok.extern.slf4j.Slf4j;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Mono;
+
+import java.io.IOException;
+import java.util.Objects;
+
+@Slf4j
+@Repository
+public class YourLinkRepository {
+
+    private final RestHighLevelClient elasticSearchClient;
+
+    @Autowired
+    public YourLinkRepository(RestHighLevelClient elasticSearchClient) {
+        this.elasticSearchClient = elasticSearchClient;
+    }
+
+    private ActionListener<IndexResponse> listener = new ActionListener<IndexResponse>() {
+        @Override
+        public void onResponse(IndexResponse indexResponse) {
+            log.debug("SUCCESS: " + indexResponse.toString());
+        }
+
+        @Override
+        public void onFailure(Exception e) {
+            log.error("Fail to save yourLink", e);
+        }
+    };
+
+    public void saveYourLink(String userId, Mono<YourLink> yourLinkMono) {
+        yourLinkMono
+                .log()
+                .map(yourLink -> {
+                    try {
+                        return new IndexRequest(yourLinkIndex(userId), "doc", yourLink.getUrl())
+                                .source(XContentFactory.jsonBuilder()
+                                        .startObject()
+                                        .field("url").value(yourLink.getUrl())
+                                        .field("tags").value(yourLink.getTags())
+                                        .field("read").value(yourLink.isRead())
+                                        .endObject());
+                    } catch (IOException e) {
+                        log.error("fail to make IndexRequest", e);
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull)
+                .subscribe(request -> elasticSearchClient.indexAsync(request, ElasticSearchClient.COMMON_OPTIONS, listener));
+    }
+
+    private String yourLinkIndex(String userId) {
+        return "yourlink_" + userId;
+    }
+}

--- a/api/src/main/java/com/bringback/yourlink/api/router/YourLinkRouter.java
+++ b/api/src/main/java/com/bringback/yourlink/api/router/YourLinkRouter.java
@@ -22,9 +22,7 @@ public class YourLinkRouter {
     }
 
     public RouterFunction<ServerResponse> routeYourLink() {
-        return route(RequestPredicates
-                        .GET("/your/links")
-                        .and(accept(MediaType.APPLICATION_JSON)),
-                yourLinkHandler::getYourLinks);
+        return route(RequestPredicates.GET("/your/links").and(accept(MediaType.APPLICATION_JSON)), yourLinkHandler::getYourLinks)
+                .andRoute(RequestPredicates.POST("/your/link/save").and(accept(MediaType.APPLICATION_JSON)), yourLinkHandler::saveYourLink);
     }
 }

--- a/api/src/main/java/com/bringback/yourlink/api/support/elasticsearch/ElasticSearchClient.java
+++ b/api/src/main/java/com/bringback/yourlink/api/support/elasticsearch/ElasticSearchClient.java
@@ -1,0 +1,45 @@
+package com.bringback.yourlink.api.support.elasticsearch;
+
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(ElasticSearchProperties.class)
+public class ElasticSearchClient {
+    private final ElasticSearchProperties elasticSearchProperties;
+
+    @Autowired
+    public ElasticSearchClient(ElasticSearchProperties elasticSearchProperties) {
+        this.elasticSearchProperties = elasticSearchProperties;
+    }
+
+    public static final RequestOptions COMMON_OPTIONS;
+    static {
+        RequestOptions.Builder builder = RequestOptions.DEFAULT.toBuilder();
+        builder.setHttpAsyncResponseConsumerFactory(
+                new HttpAsyncResponseConsumerFactory.HeapBufferedResponseConsumerFactory(30 * 1024 * 1024));
+        COMMON_OPTIONS = builder.build();
+    }
+
+    @Bean
+    public RestHighLevelClient yourLinkEsClient() {
+        return new RestHighLevelClient(
+                RestClient.builder(
+                        elasticSearchProperties.getHosts().stream()
+                        .map(hostString -> {
+                            String[] split = hostString.split(":");
+                            if (split.length < 2) {
+                                throw new IllegalArgumentException("elasticsearch.hosts need ip and port");
+                            }
+
+                            return new HttpHost(split[0], Integer.parseInt(split[1]), "http");
+                        })
+                        .map(Node::new).toArray(Node[]::new)
+                )
+        );
+    }
+}

--- a/api/src/main/java/com/bringback/yourlink/api/support/elasticsearch/ElasticSearchProperties.java
+++ b/api/src/main/java/com/bringback/yourlink/api/support/elasticsearch/ElasticSearchProperties.java
@@ -1,0 +1,12 @@
+package com.bringback.yourlink.api.support.elasticsearch;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+@Data
+@ConfigurationProperties(prefix = "elasticsearch")
+public class ElasticSearchProperties {
+    private List<String> hosts;
+}

--- a/api/src/main/resources/application-local.yml
+++ b/api/src/main/resources/application-local.yml
@@ -1,0 +1,4 @@
+elasticsearch:
+  hosts:
+    - localhost:9200
+    - localhost:9201

--- a/docker/docker-compose-es.yml
+++ b/docker/docker-compose-es.yml
@@ -1,0 +1,54 @@
+version: '2.2'
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.5.4
+    container_name: elasticsearch
+    environment:
+      - cluster.name=docker-cluster
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - esdata1:/usr/share/elasticsearch/data
+    ports:
+      - 9200:9200
+    networks:
+      - esnet
+  elasticsearch2:
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.5.4
+    container_name: elasticsearch2
+    environment:
+      - cluster.name=docker-cluster
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - "discovery.zen.ping.unicast.hosts=elasticsearch"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - esdata2:/usr/share/elasticsearch/data
+    ports:
+      - 9201:9201
+    networks:
+      - esnet
+  kibana:
+    image: docker.elastic.co/kibana/kibana:6.5.4
+    environment:
+      ELASTICSEARCH_URL: http://elasticsearch:9200
+    networks:
+      - esnet
+    ports:
+      - 5601:5601
+
+volumes:
+  esdata1:
+    driver: local
+  esdata2:
+    driver: local
+
+networks:
+  esnet:


### PR DESCRIPTION
#7 Integrate with ElasticSearch for `YourLink`

**CHANGES**
- Integrate with ElasticSearch
    - Add  ElasticSearch client library version 6.5.4
    - Implement `ElasticSearchClient`
    - Add `ElasticSearchProperties` and add properties file `application-local.yml`
- Implement save API
    - Add `/your/link/save` to `YourLinkRouter`
    - Implement `YourLinkHandler#saveYourLink`
    - Add `YourLinkRepository` and implement `YourLinkRepository#saveYourLink`
         - Set userId, it can be your email address, to index name with prefix `yourlink_`
         - Set link url to document id
         - Set `YourLink` to source
    - you can test with below curl
         ```
         curl -X POST \
               http://127.0.0.1:8080/api/v1/your/link/save \
              -H 'Content-Type: application/json' \
              -H 'x-yourlink-userid: jinok.bag@gmail.com' \
               -d '{
                      "url" : "https://github.com/bring-back/your-link",
                      "tags" : [ "bring_back", "your_link", "git" ],
                      "read" : false
               }'
          ```
- Add `docker-compose-es.yml` for local test
    - you can run ElasticSearch with this command in the terminal : `$ docker-compose -f docker-compose-es.yml up`
          - this execution will use 9200 and 9201 port of the host ( and 5601 for Kibana)
    - you can search inserted data with Kibana in browser : `http://127.0.0.1:5601`